### PR TITLE
Fix Warp10 values when user is using geo metadata

### DIFF
--- a/depc/utils/warp10.py
+++ b/depc/utils/warp10.py
@@ -17,7 +17,7 @@ def _transform_warp10_values(values):
     values_copy = {}
     for v in values:
         ts = int(v[0] / 1000000)  # ms to s
-        values_copy[ts] = v[1]
+        values_copy[ts] = v[-1]
 
     return values_copy
 


### PR DESCRIPTION
From Warp10 Docs:
```
The table of values can have two to five columns:

    [ 0 3.14 ]: timestamp, value
    [ 0 12 3.14 ]: timestamp, elevation, value
    [ 0 -45.0 0.2 3.14 ]:timestamp, latitude, longitude, value
    [ 0 48.44218 -4.41427 80000 3.14 ]: timestamp, latitude, longitude, elevation, value
```
So timestamp is always at zero index  and value is always the last.