### PR TITLE
Fix Makefile/Doc for the Scheduler part

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ui tests docs
+.PHONY: ui tests docs scheduler
 
 api:
 	python manage.py runserver

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -164,10 +164,10 @@ please read the `official documentation <https://airflow.apache.org/index.html>`
 .. code:: bash
 
     # Add the DepC root directory to the PYTHONPATH
-    export PYTHONPATH='./:$PYTHONPATH'
+    export PYTHONPATH="$(pwd)/:$PYTHONPATH"
 
     # Specify the DepC scheduler directory as the Airflow root directory
-    export AIRFLOW_HOME=scheduler/
+    export AIRFLOW_HOME="$(pwd)/scheduler"
 
     # Before this step, remember, you have to generate/configure the airflow.cfg
     make webserver


### PR DESCRIPTION
* The `make scheduler` command is now working correctly ;
* The scheduler part of the doc is now using absolute paths to add the DepC home into `PYTHONPATH` and the scheduler folder as `AIRFLOW_HOME`.

