### PR TITLE
Fix scheduler after upgrade to Airflow 1.10 and use absolute path for the YAML conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ui tests docs scheduler
+.PHONY: ui tests docs scheduler consumer
 
 api:
 	python manage.py runserver
@@ -26,3 +26,6 @@ docs: clean-docs
 
 tests:
 	pytest tests/ -vv
+
+consumer:
+	python consumer/main.py

--- a/consumer/kafka_consumer/utils.py
+++ b/consumer/kafka_consumer/utils.py
@@ -1,18 +1,17 @@
 import json
 import os
 import ssl
+from pathlib import Path
 
 import fastjsonschema
 import yaml
 from neo4j.v1 import basic_auth, TRUST_ON_FIRST_USE
 
+ENV = os.getenv("DEPC_ENV", "dev")
+HOME = os.getenv("DEPC_HOME", str(Path(__file__).resolve().parents[2]))
 
-ENV = os.environ["DEPC_ENV"]
-
-CURRENT_FOLDER = os.path.dirname(os.path.abspath(__file__))
-PARENT_FOLDER = os.path.dirname(CURRENT_FOLDER)
-SCHEMAS_PATH = os.path.join(PARENT_FOLDER, "schemas.json")
-CONFIG_PATH = os.path.join(os.path.dirname(PARENT_FOLDER), "depc.{}.yml".format(ENV))
+SCHEMAS_PATH = str(Path(HOME) / "consumer" / "schemas.json")
+CONFIG_PATH = str(Path(HOME) / "depc.{}.yml".format(ENV))
 
 # Load the DepC config YAML file
 with open(CONFIG_PATH, "r") as config_file:

--- a/consumer/main.py
+++ b/consumer/main.py
@@ -1,13 +1,11 @@
 #!/bin/env python3
-# -*- coding: utf-8 -*-
 
 import logging
 import os
 import sys
+from pathlib import Path
 
-CURRENT_FOLDER = os.path.dirname(os.path.abspath(__file__))
-PARENT_FOLDER = os.path.dirname(CURRENT_FOLDER)
-sys.path.append(PARENT_FOLDER)
+sys.path.append(os.getenv("DEPC_HOME", str(Path(__file__).resolve().parents[2])))
 
 
 if __name__ == "__main__":

--- a/depc/__init__.py
+++ b/depc/__init__.py
@@ -4,6 +4,7 @@ import importlib
 import json
 import os
 import pkgutil
+from pathlib import Path
 
 import pandas
 import yaml
@@ -13,7 +14,7 @@ from flask.json import JSONEncoder
 from flask.wrappers import Request
 from werkzeug.routing import Rule
 
-BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+BASE_DIR = str(Path(__file__).resolve().parent)
 
 
 class ExtendedRequest(Request):
@@ -135,10 +136,12 @@ def import_submodules(package, modules_to_import):
 
 
 def create_app(environment="dev"):
-
     context = importlib.import_module("depc.context")
     conf_cls = getattr(context, "{}Config".format(environment.capitalize()))
-    conf_file = "depc.{}.yml".format(environment)
+    conf_file = str(
+        Path(os.getenv("DEPC_HOME", str(Path(__file__).resolve().parents[1])))
+        / "depc.{}.yml".format(environment)
+    )
 
     # Import all modules
     import_submodules(__name__, ("models", "sources", "tasks", "apiv1"))

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,9 +55,13 @@ using the provided configuration sample in ``depc.example.yml``.
 Name the configuration file ``depc.<env>.yml`` where you should replace ``<env>`` with the
 ``DEPC_ENV`` value.
 
-Set the environment variable :
+Set these environment variables :
 
 .. code:: bash
+
+    export DEPC_HOME="$(pwd)"
+
+    # Then export, one of the following environment variable
 
     # Development environment will use a depc.dev.yml file
     export DEPC_ENV=dev
@@ -183,4 +187,4 @@ You have to configure the appropriate fields into your configuration file (secti
 
 .. code:: bash
 
-    python consumer/main.py
+    make consumer

--- a/scheduler/dags/generate_dags.py
+++ b/scheduler/dags/generate_dags.py
@@ -4,6 +4,7 @@ import math
 import re
 
 from airflow import DAG
+from airflow.executors import GetDefaultExecutor
 from airflow.models import Variable
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator
@@ -202,7 +203,13 @@ def create_subdag(dag_parent, label, team):
 
 def create_subdag_operator(dag_parent, label, team):
     subdag, dependencies = create_subdag(dag_parent, label, team)
-    sd_op = SubDagOperator(task_id=label, dag=dag_parent, subdag=subdag)
+
+    # Since v1.10, Airflow forces to use the SequentialExecutor as the default
+    # executor for the SubDagOperator, so we need to explicitly specify the
+    # executor from the airflow.cfg
+    sd_op = SubDagOperator(
+        task_id=label, dag=dag_parent, subdag=subdag, executor=GetDefaultExecutor()
+    )
     return sd_op, dependencies
 
 


### PR DESCRIPTION
* In Airflow 1.10:
https://github.com/apache/airflow/blob/master/airflow/operators/subdag_operator.py#L36
The forced use of a `SequentialExecutor` for the `SubdagOperator` cause to DepC to do not use the `airflow.cfg` (`generate_dag.py` rely on `SubdagOperator`).

* Now the configuration (e.g.: `depc.dev.yml`) will use the `DEPC_HOME` env var, the consumer, the API context and the documentation is updated accordingly.