### PR TITLE
Fix: more constraints on the rule and check name

### DIFF
--- a/depc/controllers/checks.py
+++ b/depc/controllers/checks.py
@@ -1,4 +1,9 @@
-from depc.controllers import Controller, NotFoundError
+from depc.controllers import (
+    Controller,
+    NotFoundError,
+    AlreadyExistError,
+    IntegrityError,
+)
 from depc.controllers.sources import SourceController
 from depc.models.checks import Check
 from depc.models.rules import Rule
@@ -32,8 +37,22 @@ class CheckController(Controller):
     @classmethod
     def ensure_check(cls, obj):
         """Ensure check-source compatibility and validate configuration"""
-        source = SourceController.get(filters={"Source": {"id": obj.source_id}})
-        plugin = BaseSource.load_source(source["plugin"], {})
+        name = obj.name
+
+        # Name surrounded by quotes are prohibited
+        if name.startswith(('"', "'")) or name.endswith(('"', "'")):
+            raise IntegrityError("The check name cannot begin or end with a quote")
+
+        checks = cls._list(filters={"Check": {"name": name}})
+        source = SourceController._get(filters={"Source": {"id": obj.source_id}})
+
+        for check in checks:
+            if check.id != obj.id and check.source.team_id == source.team_id:
+                raise AlreadyExistError(
+                    "The check {name} already exists.", {"name": name}
+                )
+
+        plugin = BaseSource.load_source(source.plugin, {})
         plugin.validate_check_parameters(obj.type, obj.parameters)
 
     @classmethod

--- a/depc/controllers/rules.py
+++ b/depc/controllers/rules.py
@@ -7,6 +7,7 @@ from depc.controllers import (
     Controller,
     NotFoundError,
     RequirementsNotSatisfiedError,
+    IntegrityError,
 )
 from depc.controllers.checks import CheckController
 from depc.extensions import db, redis
@@ -242,3 +243,17 @@ class RuleController(Controller):
         )
 
         return qos
+
+    @classmethod
+    def ensure_rule(cls, obj):
+        # Name surrounded by quotes are prohibited
+        if obj.name.startswith(('"', "'")) or obj.name.endswith(('"', "'")):
+            raise IntegrityError("The rule name cannot begin or end with a quote")
+
+    @classmethod
+    def before_create(cls, obj):
+        cls.ensure_rule(obj)
+
+    @classmethod
+    def before_update(cls, obj):
+        cls.ensure_rule(obj)

--- a/tests/apiv1/test_rules.py
+++ b/tests/apiv1/test_rules.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 
 
 def test_list_rules_authorization(client, create_team, create_user, create_grant):
@@ -325,3 +326,30 @@ def test_delete_rule_with_config(client, create_team, create_rule, create_user, 
     assert resp.json == {
         'message': 'Rule MyRule is used in your configuration, please remove it before.'
     }
+
+
+@pytest.mark.parametrize("test_input", ["'Test", "Test'", "'Test'", '"Test', 'Test"', '"Test"'])
+def test_post_rule_prohibited_quotes(client, create_team, create_user, create_grant, test_input):
+    team_id = str(create_team('My team')['id'])
+
+    role = 'editor'
+    user_id = str(create_user(role)['id'])
+    create_grant(team_id, user_id, role)
+    client.login(role)
+
+    resp = client.post('/v1/teams/{}/rules'.format(team_id), data=json.dumps({'name': test_input}))
+    assert resp.status_code == 400
+
+
+@pytest.mark.parametrize("test_input", ["'Test", "Test'", "'Test'", '"Test', 'Test"', '"Test"'])
+def test_put_rule_prohibited_quotes(client, create_team, create_user, create_grant, create_rule, test_input):
+    team_id = str(create_team('My team')['id'])
+    rule_id = str(create_rule('My rule', team_id)['id'])
+
+    role = 'editor'
+    user_id = str(create_user(role)['id'])
+    create_grant(team_id, user_id, role)
+    client.login(role)
+
+    resp = client.put('/v1/teams/{}/rules/{}'.format(team_id, rule_id), data=json.dumps({'name': test_input}))
+    assert resp.status_code == 400

--- a/ui/app/scripts/controllers/team/checks.js
+++ b/ui/app/scripts/controllers/team/checks.js
@@ -126,9 +126,23 @@ angular.module('depcwebuiApp')
 
     this.save = function() {
         if ( self.isReadyToSubmit() ) {
+            var params = {};
+
+            if (self.parameters.hasOwnProperty('script')) { params.script = self.parameters.script; }
+            else if (self.parameters.hasOwnProperty('query')) { params.query = self.parameters.query; }
+            else if (self.parameters.hasOwnProperty('metric')) { params.metric = self.parameters.metric; }
+
+            if (self.type.name === 'Interval') {
+                params.top_threshold = self.parameters.top_threshold;
+                params.bottom_threshold = self.parameters.bottom_threshold;
+            } else {
+                // Check is type Threshold
+                params.threshold = self.parameters.threshold;
+            }
+
             // Edit an existing check
             if ( self.mode == 'edit' ) {
-                sourcesService.editTeamCheck(self.team.id, self.source.id, self.check.id, self.name, self.type.name, self.parameters).then(function(response) {
+                sourcesService.editTeamCheck(self.team.id, self.source.id, self.check.id, self.name, self.type.name, params).then(function(response) {
                     var data = response.data;
                     var index = self.source.checks.indexOf(self.check);
                     if (index > -1) {
@@ -142,7 +156,7 @@ angular.module('depcwebuiApp')
 
             // Create a new check
             if ( self.mode == 'new' ) {
-                sourcesService.createTeamCheck(self.team.id, self.source.id, self.name, self.type.name, self.parameters).then(function(response) {
+                sourcesService.createTeamCheck(self.team.id, self.source.id, self.name, self.type.name, params).then(function(response) {
                     var data = response.data;
                     self.source.checks.push(data);
                     self.editCheck(data);


### PR DESCRIPTION
- This is not anymore possible to create 2 checks with the same name inside a team ;
- The rule and check name cannot have a simple or a double quote at the beginning or at the end of their name ;
- fix an issue when you switch the type of check.
