### PR TITLE
Add hint and link to the doc for the threshold field

### DIFF
--- a/ui/app/views/team/checks.html
+++ b/ui/app/views/team/checks.html
@@ -122,6 +122,7 @@
 					<label for="query" class="col-sm-2 control-label">Threshold</label>
 					<div class="col-sm-10">
 						<input class="form-control" id="threshold" type="text" data-ng-model="checksCtrl.threshold">
+						<p class="help-block">Simple threshold or interval : <code>42</code>, <code>3.14</code>, <code>-42</code>, <code>100:200</code> or <code>-0.1:0.1</code>. See the <a href="https://ovh.github.io/depc/guides/indicators.html">dedicated guide</a> for more details.</p>
 					</div>
 				</div>
 			</form>
@@ -158,6 +159,7 @@
 						<label for="query" class="col-sm-2 control-label">Threshold</label>
 						<div class="col-sm-10">
 							<input class="form-control" id="threshold" type="text" data-ng-model="checksCtrl.threshold">
+							<p class="help-block">Simple threshold or interval : <code>42</code>, <code>3.14</code>, <code>-42</code>, <code>100:200</code> or <code>-0.1:0.1</code>. See the <a href="https://ovh.github.io/depc/guides/indicators.html">dedicated guide</a> for more details.</p>
 						</div>
 					</div>
 


### PR DESCRIPTION
Add the text under the **Threshold** field in the **Indicator** form:
> Simple threshold or interval : `42`, `3.14`, `-42`, `100:200` or `-0.1:0.1`. See the [dedicated guide](https://ovh.github.io/depc/guides/indicators.html) for more details.

In these both cases:
- when creating a new indicator ;
- when modifying an existing one.
