### PR TITLE
CLI: add a command to create a new user

### DIFF
--- a/depc/commands/user.py
+++ b/depc/commands/user.py
@@ -1,0 +1,30 @@
+import click
+from flask.cli import AppGroup
+from flask.cli import with_appcontext
+
+from depc.controllers import NotFoundError
+from depc.controllers.users import UserController
+
+user_cli = AppGroup("user", help="Manage users.")
+
+
+@user_cli.command("create")
+@with_appcontext
+@click.argument("name", default=None, required=True, type=str)
+@click.option("--admin", default=False, required=False, type=bool, is_flag=True)
+def create_user(name, admin):
+    """Create a new user."""
+    is_admin = bool(admin)
+    try:
+        user = UserController._get(filters={"User": {"name": name}})
+        click.echo(
+            "User {name} already exists with id: {id}".format(name=name, id=user.id)
+        )
+    except NotFoundError:
+        click.confirm(
+            "User {name} will be created with admin = {admin}".format(
+                name=name, admin=is_admin
+            ),
+            abort=True,
+        )
+        UserController.create({"name": name, "active": True, "admin": is_admin})

--- a/manage.py
+++ b/manage.py
@@ -3,12 +3,14 @@ import os
 from depc import create_app
 from depc.commands.config import config_cli
 from depc.commands.key import key_cli
+from depc.commands.user import user_cli
 
 env = os.getenv("DEPC_ENV", "dev")
 
 app = create_app(environment=env)
 app.cli.add_command(config_cli)
 app.cli.add_command(key_cli)
+app.cli.add_command(user_cli)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add `flask user create <NAME>` command to the CLI.

Help output:
```
flask user create --help
Usage: flask user create [OPTIONS] NAME

  Create a new user.

Options:
  --admin
  --help      Show this message and exit.
```