### PR TITLE
fix(scheduler): use a single instance of neo4j session

### DIFF
--- a/depc/utils/neo4j.py
+++ b/depc/utils/neo4j.py
@@ -88,23 +88,22 @@ def has_active_relationship(start, end, periods):
     return len(active_periods) > 0
 
 
-def get_records(query, params={}):
+def get_session():
     config = app.config["NEO4J"]
 
     driver = BoltGraphDatabase.driver(
         config["uri"], auth=(config["username"], config["password"])
     )
-    session = driver.session()
+    return driver.session()
 
+
+def get_records(query, params={}, session=None):
+    if not session:
+        session = get_session()
     return session.read_transaction(lambda tx: tx.run(query, params))
 
 
-def set_records(query, params={}):
-    config = app.config["NEO4J"]
-
-    driver = BoltGraphDatabase.driver(
-        config["uri"], auth=(config["username"], config["password"])
-    )
-    session = driver.session()
-
+def set_records(query, params={}, session=None):
+    if not session:
+        session = get_session()
     return session.write_transaction(lambda tx: tx.run(query, params))

--- a/scheduler/dags/__init__.py
+++ b/scheduler/dags/__init__.py
@@ -1,6 +1,10 @@
 import os
 
 from depc import create_app
+from depc.utils.neo4j import get_session
 
 
 app = create_app(environment=os.getenv("DEPC_ENV") or "dev")
+
+with app.app_context():
+    neo_session = get_session()

--- a/scheduler/dags/generate_dags.py
+++ b/scheduler/dags/generate_dags.py
@@ -10,7 +10,7 @@ from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.subdag_operator import SubDagOperator
 
-from scheduler.dags import app
+from scheduler.dags import app, neo_session
 from scheduler.dags.operators import delete_redis_avg
 from scheduler.dags.operators.after_subdag_operator import AfterSubdagOperator
 from scheduler.dags.operators.aggregation_operator import AggregationOperator
@@ -153,6 +153,7 @@ def create_subdag(dag_parent, label, team):
         # All custom operators share these parameters
         params = {
             "app": app,
+            "neo_session": neo_session,
             "team": team,
             "label": label,
             "skip": skip,

--- a/scheduler/dags/operators/__init__.py
+++ b/scheduler/dags/operators/__init__.py
@@ -19,6 +19,7 @@ class QosOperator(BaseOperator):
     def __init__(self, params, *args, **kwargs):
         super(QosOperator, self).__init__(*args, **kwargs)
         self.app = params["app"]
+        self.neo_session = params.get("neo_session")
         self.team = params["team"]
         self.label = params["label"]
         self.skip = params.get("skip")
@@ -209,7 +210,7 @@ class DependenciesOperator(QosOperator):
         # Retrieve the node and its dependencies
         start_time = time.time()
         with self.app.app_context():
-            records = get_records(query)
+            records = get_records(query, self.neo_session)
         nodes = self.filter_records(
             start=start,
             end=end,

--- a/scheduler/dags/operators/rule_operator.py
+++ b/scheduler/dags/operators/rule_operator.py
@@ -36,7 +36,7 @@ class RuleOperator(QosOperator):
                 label=self.full_label, skip=self.skip, limit=int(self.length)
             )
 
-            records = get_records(query)
+            records = get_records(query, self.neo_session)
             nodes = [dict(record.get("Node").items()) for record in records]
 
             # Remove old nodes

--- a/scheduler/dags/save_config.py
+++ b/scheduler/dags/save_config.py
@@ -5,7 +5,7 @@ from airflow import DAG
 from airflow.models import Variable
 from airflow.operators.python_operator import PythonOperator
 
-from scheduler.dags import app
+from scheduler.dags import app, neo_session
 from depc.utils.neo4j import get_records
 
 logger = logging.getLogger(__name__)
@@ -63,7 +63,8 @@ def get_teams_schema(ds, **kwargs):
                     records = get_records(
                         "MATCH (n:{label}) RETURN count(n) AS Count".format(
                             label=neo_key
-                        )
+                        ),
+                        session=neo_session,
                     )
                     count = list(records)[0].get("Count")
 


### PR DESCRIPTION
A client is created in each chunk, we can reuse it. According to the `dagbag_import_timeout` parameter of Airflow a new client will be created every X seconds (default is 30).

Signed-off-by: Nicolas Crocfer <nicolas.crocfer@corp.ovh.com>