### PR TITLE
build(ui): set engines.node to >=8.0

### DIFF
--- a/ui/.npmrc
+++ b/ui/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/ui/package.json
+++ b/ui/package.json
@@ -33,7 +33,7 @@
     "time-grunt": "^1.0.0"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=8.0"
   },
   "scripts": {},
   "dependencies": {


### PR DESCRIPTION
# Set engines.node to `>=8.0`

## 👷 Build

8aa01d2 - build(ui): set engines.node to >=8.0

The Docker's image used for the UI is based on `node_8.x stretch`.

see: [`ui/Dockerfile`](https://github.com/ovh/depc/blob/4cdbca70a249abdccd0661f21fc253f0cc082bf0/ui/Dockerfile#L8-L13)

ca10dc8 - build(ui): add .npmrc file

Prevent writing `package-lock.json`.

see: https://docs.npmjs.com/misc/config#package-lock

---

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>