### PR TITLE
feat(logs): support Graylog format (GELF) for logging

### DIFF
--- a/depc.example.yml
+++ b/depc.example.yml
@@ -42,6 +42,8 @@ BEAMIUM:
 LOGGING:
     level: INFO
     format: <green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level:<8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>
+    # Enable the Graylog Extended Log Format
+    gelf: false
 
 # Configure the Kafka consumer to populate the Neo4j graph database
 # The consumer uses SASL/PLAIN authentication

--- a/depc/logs/__init__.py
+++ b/depc/logs/__init__.py
@@ -5,6 +5,7 @@ import sys
 from loguru import logger
 
 from depc.logs.handlers import InterceptHandler
+from depc.logs.sinks import GraylogExtendedLogFormatSink
 
 
 def setup_loggers(app):
@@ -37,7 +38,18 @@ def setup_loggers(app):
 
         return True
 
-    stdout_sink = {"sink": sys.stdout, "filter": stdout_filter, "level": logging_level}
+    sink = sys.stdout
+    is_serialized = False
+    if logging_config.get("gelf"):
+        sink = GraylogExtendedLogFormatSink
+        is_serialized = True
+
+    stdout_sink = {
+        "sink": sink,
+        "filter": stdout_filter,
+        "level": logging_level,
+        "serialize": is_serialized,
+    }
     logging_format = logging_config.get("format")
     if logging_format:
         stdout_sink.update({"format": logging_format})

--- a/depc/logs/sinks.py
+++ b/depc/logs/sinks.py
@@ -1,0 +1,35 @@
+import json
+
+
+class GraylogExtendedLogFormatSink:
+    """
+    Log outputs into the Graylog Extended Log Format, a.k.a. GELF.
+    """
+
+    def __init__(self, host="depc"):
+        self.host = host
+
+    def _transform_record_to_gelf(self, serialized_record):
+        json_record = json.loads(serialized_record)["record"]
+
+        # According to the documentation, extra fields are prefixed with "_".
+        # See: https://docs.graylog.org/en/latest/pages/gelf.html#gelf-payload-specification
+        payload = {
+            "version": "1.1",
+            "host": self.host,
+            "short_message": json_record["message"],
+            "level": json_record["level"]["name"],
+            "timestamp": json_record["time"]["timestamp"],
+            # "file" and "line" are sent as additional fields
+            "_file": json_record["file"]["path"],
+            "_line": json_record["line"],
+        }
+
+        # Add extra fields from logger.bind() to payload.
+        for k, v in json_record["extra"].items():
+            payload["_" + k] = v
+
+        return json.dumps(payload)
+
+    def write(self, record):
+        print(self._transform_record_to_gelf(record))


### PR DESCRIPTION
Enable GELF support into logging with the configuration (`gelf: true` in the `LOGGING` section).
Send log entries as JSON format to the standard output.
