### PR TITLE
Upgrade to pytest 4.6.6, fix issue when launching tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,10 @@
 [pytest]
+; The newer versions of pytest expect registered markers or a
+; PytestUnknownMarkWarning message is displayed
+markers =
+    ; Currently used to skip some tests when the Neo4j database is not
+    ; installed locally
+    skip_requirement: Skip if requirement is not detected/installed
 filterwarnings =
     ; alembic/util/langhelpers.py:76
     ignore:.*inspect.getargspec.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ sphinxcontrib-mermaid==0.3.1
 sphinxcontrib-httpdomain==1.7.0
 
 # Tests
-pytest==4.1.0
+pytest==4.6.6
 deepdiff==3.3.0
 pytest-cov==2.6.1
 pytest-freezegun==0.3.0.post1


### PR DESCRIPTION
Currently `make tests` will produce this error message:
```
export DEPC_ENV=test && pytest tests/ -vv
Traceback (most recent call last):
  File "/tmp/Q2xvbmUmQ2hlY2s/run/venv/bin/pytest", line 8, in <module>
    sys.exit(main())
  File "/tmp/Q2xvbmUmQ2hlY2s/run/venv/lib/python3.6/site-packages/_pytest/config/__init__.py", line 61, in main
    config = _prepareconfig(args, plugins)
  File "/tmp/Q2xvbmUmQ2hlY2s/run/venv/lib/python3.6/site-packages/_pytest/config/__init__.py", line 182, in _prepareconfig
    config = get_config()
  File "/tmp/Q2xvbmUmQ2hlY2s/run/venv/lib/python3.6/site-packages/_pytest/config/__init__.py", line 156, in get_config
    pluginmanager.import_plugin(spec)
  File "/tmp/Q2xvbmUmQ2hlY2s/run/venv/lib/python3.6/site-packages/_pytest/config/__init__.py", line 530, in import_plugin
    __import__(importspec)
  File "/tmp/Q2xvbmUmQ2hlY2s/run/venv/lib/python3.6/site-packages/_pytest/tmpdir.py", line 25, in <module>
    class TempPathFactory(object):
  File "/tmp/Q2xvbmUmQ2hlY2s/run/venv/lib/python3.6/site-packages/_pytest/tmpdir.py", line 35, in TempPathFactory
    lambda p: Path(os.path.abspath(six.text_type(p)))
TypeError: attrib() got an unexpected keyword argument 'convert'
```
The pytest 4.6.6 release fixed this issue by updating requirements to `attrs>=19.2` (see [pytest changelog](https://docs.pytest.org/en/latest/changelog.html#pytest-4-6-6-2019-10-11)).
