### PR TITLE
Exclude some nodes from the label average

### DIFF
--- a/depc/schemas/v1_config.json
+++ b/depc/schemas/v1_config.json
@@ -8,6 +8,21 @@
         "additionalProperties": false,
         "required": ["qos"],
         "properties": {
+          "label": {
+            "description": "Extra fields affecting the label",
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["average.exclude"],
+            "properties": {
+              "average.exclude": {
+                "description": "Exclusion list of nodes from the compute of the Label average QOS",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
           "qos": {
             "description": "The QOS query",
             "type": "string",

--- a/scheduler/dags/generate_dags.py
+++ b/scheduler/dags/generate_dags.py
@@ -172,7 +172,15 @@ def create_subdag(dag_parent, label, team):
 
         before_subdag_task = BeforeSubdagOperator(
             task_id="{}.before_subdag".format(label),
-            params={"app": app, "team": team, "label": label, "count": count},
+            params={
+                "app": app,
+                "team": team,
+                "label": label,
+                "count": count,
+                "excluded_nodes_from_average": schema.get("label", {}).get(
+                    "average.exclude"
+                ),
+            },
         )
 
         after_subdag_task = AfterSubdagOperator(

--- a/scheduler/dags/operators/before_subdag_operator.py
+++ b/scheduler/dags/operators/before_subdag_operator.py
@@ -2,6 +2,7 @@ import time
 
 from airflow.utils.decorators import apply_defaults
 
+from depc.extensions import redis_scheduler as redis
 from scheduler.dags.operators import QosOperator
 
 
@@ -10,9 +11,22 @@ class BeforeSubdagOperator(QosOperator):
     def __init__(self, params, *args, **kwargs):
         super(BeforeSubdagOperator, self).__init__(params, *args, **kwargs)
         self.count = params["count"]
+        self.excluded_nodes_from_average = params["excluded_nodes_from_average"]
 
     def execute(self, context):
         from depc.utils import get_start_end_ts
+
+        self.logger.info(
+            "Excluded nodes for {label}: {excluded}".format(
+                label=self.label, excluded=self.excluded_nodes_from_average
+            )
+        )
+        if self.excluded_nodes_from_average:
+            redis_key = "{team}.{label}.excluded_nodes_from_label_average".format(
+                team=self.team_name, label=self.label
+            )
+            redis.delete(redis_key)
+            redis.rpush(redis_key, *self.excluded_nodes_from_average)
 
         ds = context["ds"]
         start, end = get_start_end_ts(ds)

--- a/scheduler/dags/operators/rule_operator.py
+++ b/scheduler/dags/operators/rule_operator.py
@@ -92,9 +92,13 @@ class RuleOperator(QosOperator):
                     key = "{ds}.{team}.{label}".format(
                         ds=ds, team=self.team_name, label=self.label
                     )
-                    redis.zadd(
-                        "{}.sorted".format(key), node["name"], result["qos"]["qos"]
-                    )
+
+                    if not self.excluded_from_label_average(
+                        self.team_name, self.label, node["name"]
+                    ):
+                        redis.zadd(
+                            "{}.sorted".format(key), node["name"], result["qos"]["qos"]
+                        )
 
                     # Save information to reuse it later (`bools_dps` is used in
                     # OperationOperator and `qos` is used in AggregationOperator)


### PR DESCRIPTION
Introducing a new property into the user's configuration in order to exclude specific nodes from the label average computing.

Sample:
```
{
 "Apache": {
  "label": {
   "average.exclude": [
    "apache1"
   ]
  },
  "qos": "rule.Servers"
 },
 "Filer": {
  "qos": "rule.Servers"
 },
 "Offer": {
  "qos": "aggregation.AVERAGE[Website]"
 },
 "Website": {
  "qos": "operation.AND[Filer, Apache]"
 }
}
```
New feature:
```
"label": {
  "average.exclude": [
    "apache1"
  ]
}
```

This configuration means you can have a QoS for the `apache1` and prevent this node to affect the average of the label `Apache`.

Possible use case: you are using some staging nodes into your infrastructure computed by DepC but this node should not contribute to your overall QoS.
