### PR TITLE
bump(scheduler): upgrade to apache airflow 1.10.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ aiohttp==2.3.10
 yarl==1.1.1
 
 # Apache Airflow
-apache-airflow==1.10.3
+apache-airflow==1.10.6
 cryptography==2.4.2
 
 # SqlAlchemy

--- a/scheduler/dags/generate_dags.py
+++ b/scheduler/dags/generate_dags.py
@@ -4,7 +4,7 @@ import math
 import re
 
 from airflow import DAG
-from airflow.executors import GetDefaultExecutor
+from airflow.executors import get_default_executor
 from airflow.models import Variable
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator
@@ -216,7 +216,7 @@ def create_subdag_operator(dag_parent, label, team):
     # executor for the SubDagOperator, so we need to explicitly specify the
     # executor from the airflow.cfg
     sd_op = SubDagOperator(
-        task_id=label, dag=dag_parent, subdag=subdag, executor=GetDefaultExecutor()
+        task_id=label, dag=dag_parent, subdag=subdag, executor=get_default_executor()
     )
     return sd_op, dependencies
 


### PR DESCRIPTION
Upgrade the Apache Airflow version, fix the `ImportError` with `GetDefaultExecutor()` (replaced by: `get_default_executor()`).

NB: when upgrading from a previous version of Apache Airflow, you may need to add a `default_pool` into the Pool list (admin panel).
