### PR TITLE
feat: disable the default auto-filling for some specific use cases

### DIFF
--- a/depc.example.yml
+++ b/depc.example.yml
@@ -59,3 +59,9 @@ CONSUMER:
         group_id: depc.consumer.depc_consumer_group
     heartbeat:
         delay: 5
+
+# Optional: exclude a specific team or rule from the regular QoS compute method
+# This variable needs a list of UUIDs used in the database
+# The compute for these IDs will be based only on the data points sent by the source
+EXCLUDE_FROM_AUTO_FILL:
+    - 123e4567-e89b-12d3-a456-426655440000

--- a/depc/apiv1/rules.py
+++ b/depc/apiv1/rules.py
@@ -4,6 +4,7 @@ from flask_login import login_required
 from depc.apiv1 import api, format_object, get_payload
 from depc.controllers.rules import RuleController
 from depc.users import TeamPermission
+from depc.utils.qos import check_enable_auto_fill
 
 VISIBLE = ["name", "description", "checks"]
 
@@ -244,5 +245,7 @@ def execute_rule(team_id, rule_id):
     # Does the team owns the rule
     RuleController.get({"Rule": {"id": rule_id, "team_id": team_id}})
 
-    result = RuleController.execute(rule_id, **payload)
+    result = RuleController.execute(
+        rule_id=rule_id, auto_fill=check_enable_auto_fill(rule_id, team_id), **payload
+    )
     return jsonify({"result": result}), 200

--- a/depc/context.py
+++ b/depc/context.py
@@ -46,6 +46,7 @@ class Config:
     STATIC_DIR = str(Path(BASE_DIR) / "static")
     SQLALCHEMY_TRACK_MODIFICATIONS = True
     MAX_WORST_ITEMS = 15
+    EXCLUDE_FROM_AUTO_FILL = []
 
     @staticmethod
     def init_app(app):

--- a/depc/sources/__init__.py
+++ b/depc/sources/__init__.py
@@ -102,7 +102,7 @@ class BaseSource(object):
     async def execute(self, parameters, name, start, end):
         raise NotImplementedError
 
-    async def run(self, parameters, name, start, end):
+    async def run(self, parameters, name, start, end, auto_fill):
         timeseries = await self.execute(parameters, name, start, end)
         threshold = parameters["threshold"]
 
@@ -127,7 +127,7 @@ class BaseSource(object):
                 "Bad threshold format : {}".format(parameters["threshold"])
             )
 
-        result = compute_qos_from_bools(bool_per_ts, start, end)
+        result = compute_qos_from_bools(bool_per_ts, start, end, auto_fill=auto_fill)
         result.update({"timeseries": timeseries})
 
         return result

--- a/depc/tasks.py
+++ b/depc/tasks.py
@@ -20,7 +20,7 @@ def write_log(logs, message, level):
     return logs
 
 
-async def execute_asyncio_check(check, name, start, end, key, variables):
+async def execute_asyncio_check(check, name, start, end, key, variables, auto_fill):
     logs = []
     logs = write_log(
         logs, "[{0}] Executing check ({1})...".format(check.name, check.id), "INFO"
@@ -56,7 +56,11 @@ async def execute_asyncio_check(check, name, start, end, key, variables):
 
         try:
             check_result = await source_plugin.run(
-                parameters=parameters, name=name, start=start, end=end
+                parameters=parameters,
+                name=name,
+                start=start,
+                end=end,
+                auto_fill=auto_fill,
             )
         except UnknownStateException as e:
             error = e
@@ -103,7 +107,7 @@ async def execute_asyncio_check(check, name, start, end, key, variables):
     return {"logs": logs, "result": result}
 
 
-def merge_all_checks(checks, rule, key, context):
+def merge_all_checks(checks, rule, key, auto_fill, context):
     result = {"context": context, "logs": []}
 
     # Remove the result key
@@ -119,7 +123,7 @@ def merge_all_checks(checks, rule, key, context):
 
     if checks_copy:
         result_rule = compute_qos_from_bools(
-            booleans=[c["bools_dps"] for c in checks_copy]
+            booleans=[c["bools_dps"] for c in checks_copy], auto_fill=auto_fill
         )
         result.update(result_rule)
 

--- a/scheduler/dags/operators/rule_operator.py
+++ b/scheduler/dags/operators/rule_operator.py
@@ -3,6 +3,7 @@ import json
 from airflow.utils.decorators import apply_defaults
 
 from depc.utils.neo4j import is_active_node, get_records
+from depc.utils.qos import check_enable_auto_fill
 from scheduler.dags.operators import QosOperator
 
 
@@ -56,10 +57,11 @@ class RuleOperator(QosOperator):
                 return False
 
             has_qos = False
+            auto_fill = check_enable_auto_fill(rule["id"], self.team_id)
             for node in nodes:
                 result = RuleController.execute(
                     rule_id=rule["id"],
-                    sync=True,
+                    auto_fill=auto_fill,
                     name=node["name"],
                     start=start,
                     end=end,


### PR DESCRIPTION
Use the `EXCLUDE_FROM_AUTO_FILL` in the DepC configuration YAML file to specify which resource (team IDs or rule IDs*) you want to exclude from the regular compute method.
Under the hood, this option will prevent the data points to be back-filled and forward-filled into the Pandas dataframe during the QoS computing.

Example:
```
EXCLUDE_FROM_AUTO_FILL:
    - 123e4567-e89b-12d3-a456-426655440000
```

\* The UUIDs for the teams and the rules used as primary keys in the DepC relational database.