### PR TITLE
fix(ui,api): encode/decode node name with special characters

### DIFF
--- a/depc/apiv1/dependencies.py
+++ b/depc/apiv1/dependencies.py
@@ -1,3 +1,5 @@
+from urllib.parse import unquote
+
 import arrow
 from flask import abort, jsonify, request
 from flask_login import login_required
@@ -137,7 +139,9 @@ def count_node_dependencies(team_id, label, node):
     if not TeamPermission.is_user(team_id):
         abort(403)
 
-    return jsonify(DependenciesController.count_node_dependencies(team_id, label, node))
+    return jsonify(
+        DependenciesController.count_node_dependencies(team_id, label, unquote(node))
+    )
 
 
 @api.route("/teams/<team_id>/labels/<label>/nodes/<path:node>")
@@ -220,7 +224,7 @@ def get_node(team_id, label, node):
         abort(403)
 
     # We just want to return the node
-    data = DependenciesController.get_label_node(team_id, label, node)
+    data = DependenciesController.get_label_node(team_id, label, unquote(node))
     if request.args.get("alone", False):
         return jsonify(data)
 
@@ -324,7 +328,7 @@ def get_impacted_nodes(team_id, label, node):
         DependenciesController.get_impacted_nodes(
             team_id,
             label,
-            node,
+            unquote(node),
             request.args.get("impactedLabel", None),
             request.args.get("skip", 0),
             request.args.get("limit", 25),
@@ -368,7 +372,7 @@ def get_impacted_nodes_count(team_id, label, node):
 
     return jsonify(
         DependenciesController.get_impacted_nodes_count(
-            team_id, label, node, request.args.get("impactedLabel", None)
+            team_id, label, unquote(node), request.args.get("impactedLabel", None)
         )
     )
 
@@ -416,7 +420,7 @@ def get_impacted_nodes_all(team_id, label, node):
     json_string = DependenciesController.get_impacted_nodes_all(
         team_id,
         label,
-        node,
+        unquote(node),
         request.args.get("impactedLabel", None),
         request.args.get("ts", None),
         request.args.get("inactive", False),

--- a/ui/app/scripts/services/dependencies.js
+++ b/ui/app/scripts/services/dependencies.js
@@ -43,20 +43,20 @@ angular.module('depcwebuiApp')
 
     var getTeamLabelNode = function(team_id, label, node) {
       return $http({
-        url: config.depc_endpoint() + '/teams/' + team_id + '/labels/' + label + '/nodes/' + node + '?alone=1',
+        url: config.depc_endpoint() + '/teams/' + team_id + '/labels/' + label + '/nodes/' + encodeURIComponent(node) + '?alone=1',
         method: "GET"
       });
     };
 
     var countNodeDependencies = function(team_id, label, node) {
       return $http({
-        url: config.depc_endpoint() + '/teams/' + team_id + '/labels/' + label + '/nodes/' + node + '/count',
+        url: config.depc_endpoint() + '/teams/' + team_id + '/labels/' + label + '/nodes/' + encodeURIComponent(node) + '/count',
         method: "GET"
       });
     };
 
     var getNodeDependencies = function(team_id, label, node, day, filteredByConfig, includingInactive, displayImpacted) {
-      var url = config.depc_endpoint() + '/teams/' + team_id + '/labels/' + label + '/nodes/' + node + '?1=1';
+      var url = config.depc_endpoint() + '/teams/' + team_id + '/labels/' + label + '/nodes/' + encodeURIComponent(node) + '?1=1';
 
       if ( day ) {
         url = url + '&day=' + day;
@@ -81,7 +81,7 @@ angular.module('depcwebuiApp')
     };
 
     var deleteNode = function(team_id, label, node, detach) {
-      var url = config.depc_endpoint() + '/teams/' + team_id + '/labels/' + label + '/nodes/' + node;
+      var url = config.depc_endpoint() + '/teams/' + team_id + '/labels/' + label + '/nodes/' + encodeURIComponent(node);
 
       if ( detach ) {
         url = url + '?detach=1';
@@ -94,7 +94,7 @@ angular.module('depcwebuiApp')
     }
 
     var getTeamImpactedNodes = function(teamId, label, node, impactedLabel, skip, limit, unixTs) {
-      var url = config.depc_endpoint() + '/teams/' + teamId + '/labels/' + label + '/nodes/' + node + '/impacted';
+      var url = config.depc_endpoint() + '/teams/' + teamId + '/labels/' + label + '/nodes/' + encodeURIComponent(node) + '/impacted';
 
       // We do not know the order of parameters, so this dirty patch abstracts it
       url += '?1=1';
@@ -122,7 +122,7 @@ angular.module('depcwebuiApp')
     };
 
     var getTeamImpactedNodesCount = function(teamId, label, node, impactedLabel) {
-      var url = config.depc_endpoint() + '/teams/' + teamId + '/labels/' + label + '/nodes/' + node + '/impacted/count';
+      var url = config.depc_endpoint() + '/teams/' + teamId + '/labels/' + label + '/nodes/' + encodeURIComponent(node) + '/impacted/count';
 
       if (impactedLabel) {
         url += '?impactedLabel=' + impactedLabel;
@@ -135,7 +135,7 @@ angular.module('depcwebuiApp')
     };
 
     var getTeamImpactedNodesAll = function(teamId, label, node, impactedLabel, unixTs, inactive) {
-      var url = config.depc_endpoint() + '/teams/' + teamId + '/labels/' + label + '/nodes/' + node + '/impacted/all';
+      var url = config.depc_endpoint() + '/teams/' + teamId + '/labels/' + label + '/nodes/' + encodeURIComponent(node) + '/impacted/all';
 
       // We do not know the order of parameters, so this dirty patch abstracts it
       url += '?1=1';


### PR DESCRIPTION
Fix issue with some characters (e.g.: `?`,...) in the node name causing a `404` error in the Dependencies tab (node search feature).

API call: `https://localhost:5000/#/teams/Acme/dependencies?day=2020-05-07&label=Test&node=%2Ftest%2Fplop%2Fok%3Ftest%3Dok%23TEST`

<img width="499" alt="image" src="https://user-images.githubusercontent.com/2952824/81323843-53952980-9096-11ea-8e87-1707bfdd2dc2.png">
