### PR TITLE
Fixes: requirements and grafana templates

### DIFF
--- a/depc/static/grafana_details_dashboard.json
+++ b/depc/static/grafana_details_dashboard.json
@@ -5,7 +5,7 @@
         "label": "Depc Warp10",
         "description": "",
         "type": "datasource",
-        "pluginId": "grafana-warp10-datasource",
+        "pluginId": "ovh-warp10-datasource",
         "pluginName": "Warp10"
       }
     ],
@@ -18,7 +18,7 @@
       },
       {
         "type": "datasource",
-        "id": "grafana-warp10-datasource",
+        "id": "ovh-warp10-datasource",
         "name": "Warp10",
         "version": "2.1.0"
       },

--- a/depc/static/grafana_summary_dashboard.json
+++ b/depc/static/grafana_summary_dashboard.json
@@ -5,7 +5,7 @@
       "label": "Depc Warp10",
       "description": "",
       "type": "datasource",
-      "pluginId": "grafana-warp10-datasource",
+      "pluginId": "ovh-warp10-datasource",
       "pluginName": "Warp10"
     }
   ],
@@ -18,7 +18,7 @@
     },
     {
       "type": "datasource",
-      "id": "grafana-warp10-datasource",
+      "id": "ovh-warp10-datasource",
       "name": "Warp10",
       "version": "2.1.0"
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ apache-airflow==1.10.10
 cryptography==2.4.2
 
 # SqlAlchemy
-alembic==0.8.10
+alembic==1.4.2
 psycopg2-binary==2.7.5
 sqlalchemy==1.3.0
 sqlalchemy-utils==0.33.10
@@ -30,10 +30,10 @@ sqlalchemy-utils==0.33.10
 # Flask
 click==7.0
 flask==1.1.1
-flask-admin==1.5.3
+flask-admin==1.5.4
 flask-cors==2.1.2
 flask-jsonschema==0.1.1
-flask-login==0.2.11
+flask-login==0.4.1
 flask-migrate==2.2.1
 flask-sqlalchemy==2.4.1
 


### PR DESCRIPTION
* Due to a conflict with some versions of `flask-admin`, `flask-login` and `alembic`, this PR updates DepC requirements to match Airflow/FlaskAppBuilder requirements.

* Update Grafana templates to change the PluginID for the current [Warp10 data source](https://github.com/ovh/ovh-warp10-datasource/blob/master/plugin.json#L2).
