### PR TITLE
feat: support snappy compression in kafka consumer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,13 @@ python:
 services:
   - neo4j
 
+addons:
+  apt:
+    packages:
+      - libsnappy-dev
+
 install:
+  - pip install python-snappy==0.5.4
   - pip install -r requirements.txt
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.6
 ENTRYPOINT ["./docker-entrypoint.sh"]
 EXPOSE 5000
 
+RUN apt-get update && apt-get install -y libsnappy-dev
+
 # Working directory
 RUN mkdir -p /app
 WORKDIR /app

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -153,7 +153,7 @@ To start the Web UI :
 
 Now, you can reach the DepC Web UI at : ``http://localhost:9000/#/teams`` :
 
-.. figure:: _static/images/empty_homepage.png
+.. figure:: _static/images/installation/empty_homepage.png
    :alt: DepC Empty Homepage
    :align: center
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -49,6 +49,15 @@ Install the requirements
 
     pip install -r requirements.txt
 
+.. note::
+    To support the `Snappy compression library <https://github.com/google/snappy>`__ for the Kafka consumer,
+    on Debian-based Linux distribution you have to install the ``libsnappy-dev`` package. Then you can install
+    the related Python package.
+
+    .. code:: bash
+
+        pip install python-snappy==0.5.4
+
 
 Configure your environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
New info block in installation documentation looks like this:
<img width="769" alt="image" src="https://user-images.githubusercontent.com/2952824/88544235-5f4f1700-d019-11ea-82cf-c0ab4f015948.png">
