### PR TITLE
fix(docker): add python-snappy package installation in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV AIRFLOW_GPL_UNIDECODE yes
 # Install the Python requirements
 ADD requirements.txt /app/
 RUN pip install --upgrade pip
+RUN pip install python-snappy==0.5.4
 RUN pip install -r requirements.txt
 
 # Copy the source files


### PR DESCRIPTION
**Fix Pull Request #78** 
As a part of an optional requirement, the `pip install python-snappy` step should be added directly in the `Dockerfile`, not in the `requirements.txt`.