### PR TITLE
Dev/aolea/fix dependency docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
     <p align="center"><img alt="DepC logo" src="https://raw.githubusercontent.com/ovh/depc/master/depc_logo.png"></p>
     <p align="center">
         <a href="https://travis-ci.org/ovh/depc"><img alt="Build status" src="https://travis-ci.org/ovh/depc.svg?branch=master"></a>
-        <a href="https://www.python.org/"><img alt="Python versions" src="https://img.shields.io/badge/python-3.5%2B-blue.svg"></a>
+        <a href="https://www.python.org/"><img alt="Python versions" src="https://img.shields.io/badge/python-3.6%2B-blue.svg"></a>
         <a href="https://github.com/ovh/depc/blob/master/LICENSE"><img alt="License" src="https://img.shields.io/badge/license-BSD%203--Clause-blue.svg"></a>
         <a href="https://github.com/python/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
     </p>

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,7 +31,7 @@ Take a look on the ``depc.example.yml`` to set the required configuration fields
 Create your virtual environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You may need to install Python 3.6+ first, this step can differ depending on your operating system,
+You may need to install **Python 3.6+** first, this step can differ depending on your operating system,
 please refer to the official `Python documentation <https://docs.python.org/3/using/index.html>`__
 for further details.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -225,6 +225,14 @@ The WebUI is available at http://127.0.0.1:8080 :
    :alt: Airflow WebServer
    :align: center
 
+.. note::
+
+    To secure the Airflow Web UI, you can read the
+    `Security section <https://airflow.apache.org/docs/1.10.11/security.html>`__
+    and the
+    `Security Connections How-To guide <https://airflow.apache.org/docs/1.10.11/howto/secure-connections.html>`__
+    in the official Airflow documentation.
+
 As you can see Airflow indicates that the scheduler is not running. Before doing it
 we need to change the `captchup` configuration :
 
@@ -240,7 +248,7 @@ You can now start the scheduler :
 
     $ make scheduler
 
-As you can see in the web interface the message has disapeared. You can now activate the
+As you can see in the web interface the message has disappeared. You can now activate the
 `config` DAG :
 
 .. figure:: _static/images/installation/airflow_webserver_config.png

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ yarl==1.1.1
 
 # Apache Airflow
 apache-airflow==1.10.11
-cryptography==2.4.2
 
 # SqlAlchemy
 alembic==1.4.2


### PR DESCRIPTION
The `cryptography` package depends on Apache Airflow and can be installed via `pip install apache-airflow[crypto]`, it's now removed from the `requirements.txt`.
The documentation is also updated with useful links to reflect this change.

Update README and documentation to emphasize the support of `Python 3.6+`.
