### PR TITLE
Features for Airflow DAGs

### DIFF
--- a/scheduler/dags/generate_dags.py
+++ b/scheduler/dags/generate_dags.py
@@ -243,11 +243,21 @@ def create_dag(team, schedule_interval, default_args):
     return dag
 
 
-# Create the DAGs
 teams = Variable.get("config", default_var=[], deserialize_json=True)
+# You need to go on the Variables page of the Airflow Web UI, e.g.: http://localhost:8080/admin/variable/
+# Then create a new Variable with a key "schedules" and for value, e.g.: {"slug_of_the_team": "15 2 * * *"}
+custom_schedule_intervals = Variable.get(
+    "schedules", default_var={}, deserialize_json=True
+)
+# Create the DAGs
 for team in teams:
     try:
-        globals()[team["topic"]] = create_dag(team, schedule_interval, default_args)
+        team_schedule_interval = custom_schedule_intervals.get(
+            team["topic"], schedule_interval
+        )
+        globals()[team["topic"]] = create_dag(
+            team, team_schedule_interval, default_args
+        )
     except Exception as e:
         logger.error(
             "Exception in team {team} : {exc}".format(team=team["name"], exc=str(e))


### PR DESCRIPTION
Enable an Airflow admin to change some DepC DAGs parameters (chunks, schedule intervals) into the Airflow Web UI (_Admin > Variables_).
By default, the variables do not exist in the Airflow database, the default existing behaviour is applied.

**Variable: `chunks`**
Value: `{ "amount": 100, "min_count": 100 }`
Configure when you want to enable the chunk feature. Define the number of chunks with the sub-key `amount` and when to apply chunks (number to nodes).

**Variable: `schedules`**
Value: `{ "team_foo": "15 1 * * *", "team_bar": "30 2 * * *" }`
You can run some DepC team DAGs with different schedule intervals using the crontab syntax.