### PR TITLE
fix: rework case when compute qos handles one datapoint with no autofill feature

### DIFF
--- a/depc/utils/qos.py
+++ b/depc/utils/qos.py
@@ -87,10 +87,14 @@ def _compute_qos(booleans, start, end, agg_op, auto_fill, float_decimal):
     # Apply an aggregation between all series
     merged_ts["Results"] = agg_op(merged_ts)
 
-    # If we just have 1 timestamp,
-    # the QOS is this value
-    if merged_ts.Results.size == 1:
-        return 100.0 if merged_ts.Results.bool() else 0.0
+    # If we just have only 1 timestamp, when the autofill feature is disable
+    if not auto_fill and merged_ts.Results.size == 1:
+        qos = 100.0 if merged_ts.Results.bool() else 0.0
+        return {
+            "qos": qos,
+            "bools_dps": merged_ts.Results.to_dict(),
+            "periods": {"ko": 0, "ok": 1} if qos == 100.0 else {"ko": 1, "ok": 0},
+        }
 
     # Only keep the changes to reduce the size
     normalized_results = merged_ts.Results[

--- a/tests/utils/test_qos.py
+++ b/tests/utils/test_qos.py
@@ -17,6 +17,64 @@ def test_compute_qos_empty():
     assert DeepDiff(expected, actual, ignore_order=True) == {}
 
 
+def test_compute_qos_one_good_datapoint():
+    data = pd.Series({1595980800: True})
+    expected = {
+        "bools_dps": {1595980800: True, 1596067199: True},
+        "periods": {"ko": 0, "ok": 86399},
+        "qos": 100.0,
+    }
+    actual = _compute_qos([data], start=1595980800, end=1596067199, **DEFAULT_ARGS)
+    assert DeepDiff(expected, actual, ignore_order=True) == {}
+
+
+def test_compute_qos_one_bad_datapoint():
+    data = pd.Series({1595980800: False})
+    expected = {
+        "bools_dps": {1595980800: False, 1596067199: False},
+        "periods": {"ko": 86399, "ok": 0},
+        "qos": 0.0,
+    }
+    actual = _compute_qos([data], start=1595980800, end=1596067199, **DEFAULT_ARGS)
+    assert DeepDiff(expected, actual, ignore_order=True) == {}
+
+
+def test_compute_qos_one_good_datapoint_no_autofill():
+    data = pd.Series({1595980800: True})
+    expected = {
+        "bools_dps": {1595980800: True},
+        "periods": {"ko": 0, "ok": 1},
+        "qos": 100.0,
+    }
+    actual = _compute_qos(
+        [data],
+        start=1595980800,
+        end=1596067199,
+        agg_op=OperationTypes.AND,
+        auto_fill=False,
+        float_decimal=3,
+    )
+    assert DeepDiff(expected, actual, ignore_order=True) == {}
+
+
+def test_compute_qos_one_bad_datapoint_no_autofill():
+    data = pd.Series({1595980800: False})
+    expected = {
+        "bools_dps": {1595980800: False},
+        "periods": {"ko": 1, "ok": 0},
+        "qos": 0.0,
+    }
+    actual = _compute_qos(
+        [data],
+        start=1595980800,
+        end=1596067199,
+        agg_op=OperationTypes.AND,
+        auto_fill=False,
+        float_decimal=3,
+    )
+    assert DeepDiff(expected, actual, ignore_order=True) == {}
+
+
 def test_compute_qos_good_values():
     data = pd.Series({1595980800: True, 1595994060: True})
     expected = {


### PR DESCRIPTION
- Value returned by `_compute_qos(..)` was wrong, happened in case of `autofill=False` (e.g.: `EXCLUDE_FROM_AUTO_FILL` from the DepC configuration) with only one data point from the time serie.
- Add some test cases.
