### PR TITLE
fix(ui,requirements): avoid unwanted bump for color hash and async-timeout

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ pyyaml==4.2b1
 redis==2.10.5
 requests==2.20.0
 werkzeug==0.15.4
+async-timeout==3.0.1
 aiohttp==2.3.10
 yarl==1.1.1
 

--- a/ui/bower.json
+++ b/ui/bower.json
@@ -23,7 +23,7 @@
     "angular-toastr": "^2.1.1",
     "angular-confirm-modal": "^1.2.6",
     "angular-chart.js": "^1.1.1",
-    "color-hash": "^1.0.3",
+    "color-hash": "1.0.3",
     "angular-daterangepicker": "^0.2.2",
     "moment": "^2.10.2",
     "angular-bootstrap-datetimepicker": "^1.1.3",


### PR DESCRIPTION
- Fix `color-hash` lib version due to a bug in the UI with new version.
- Fix `async-timeout` lib version (inherited from `aiohttp`) to avoid issue into the API.
